### PR TITLE
Fix for Multi-Threaded Contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.15", features = ["sync", "time"] }
 
 [dev-dependencies]
 rand = "0.8"
+pretty_assertions = "1.4"
 tokio = { version = "1.15", features = ["full", "macros", "test-util"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weighted_rate_limiter"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A weighted rate limiter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["weighted", "rate", "limiter", "limit", "throttle"]
 [dependencies]
 futures = "0.3"
 queues = "1.1"
-tokio = { version = "1.15", features = ["time"] }
+tokio = { version = "1.15", features = ["sync", "time"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -57,9 +57,10 @@ impl RateLimiter {
         }
 
         while next_job_id != job_id {
-            self.wait_until_weight_is_released()
-                .expect("wait_until_weight_is_released is None")
-                .await;
+            if let Some(fut) = self.wait_until_weight_is_released() {
+                fut.await;
+            }
+
             {
                 let queue = self.queued_jobs.lock().await;
                 next_job_id = queue

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -2,7 +2,8 @@ use crate::WeightManager;
 
 use std::collections::VecDeque;
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,7 +31,7 @@ impl RateLimiter {
     }
 
     fn make_id() -> u64 {
-        COUNTER.fetch_add(1, Relaxed)
+        COUNTER.fetch_add(1, Ordering::SeqCst)
     }
 
     fn wait_until_weight_is_released(&self) -> Option<Sleep> {

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -57,8 +57,11 @@ impl RateLimiter {
         }
 
         while next_job_id != job_id {
-            if let Some(fut) = self.wait_until_weight_is_released() {
-                fut.await;
+            // If we would need to wait anyway, do some waiting.
+            if self.limiter.remaining_weight() < weight {
+                if let Some(fut) = self.wait_until_weight_is_released() {
+                    fut.await;
+                }
             }
 
             {

--- a/src/weight_manager.rs
+++ b/src/weight_manager.rs
@@ -86,8 +86,7 @@ impl WeightManager {
     }
 
     /// Release any expired weight reservations back to the total pool and return the total remaining.
-    #[cfg(test)]
-    fn remaining_weight(&self) -> u64 {
+    pub fn remaining_weight(&self) -> u64 {
         let now = Instant::now();
         self.release_weight(&now);
         self.remaining_weight.load(Ordering::SeqCst)
@@ -97,10 +96,12 @@ impl WeightManager {
     pub fn time_of_next_weight_released(&self) -> Option<Instant> {
         let now = Instant::now();
         self.release_weight(&now);
-        match self.reserved_weights.lock().unwrap().peek() {
-            Ok(x) => Some(x.time_to_release_weight),
-            Err(_) => None,
-        }
+        self.reserved_weights
+            .lock()
+            .unwrap()
+            .peek()
+            .ok()
+            .map(|x| x.time_to_release_weight)
     }
 }
 

--- a/tests/rate_limiter.rs
+++ b/tests/rate_limiter.rs
@@ -162,7 +162,7 @@ async fn test_multi_threaded() {
         let ordered_job_ids_and_notifies = job_ids_and_notifies.clone();
         let results = results.clone();
 
-        let fut = task::spawn(async move {
+        let fut = async move {
             let mut thread_futures = vec![];
             let current_thread_job_ids_and_notifies: Vec<(usize, (JobId, &Notify))> =
                 ordered_job_ids_and_notifies
@@ -186,7 +186,7 @@ async fn test_multi_threaded() {
             }
 
             join_all(thread_futures).await;
-        });
+        };
 
         futures.push(fut);
     }

--- a/tests/rate_limiter.rs
+++ b/tests/rate_limiter.rs
@@ -78,10 +78,67 @@ async fn test_multiple_concurrent() {
     assert_eq!(Instant::now() - start, Duration::from_secs(2)); // We must have waited 2 seconds to fire 3 things
 }
 
-/// Have 5 threads, each submitting 3 jobs. All jobs will have weight 1. We will use barriers such that
+/// Have 5 tasks, each submitting 3 jobs. All jobs will have weight 1. We will use barriers such that
 /// the jobs are submitted in batches; one from each thread. We want to check that the number of jobs executed
 /// each second is as expected.
 #[tokio::test(start_paused = true)]
+async fn test_multi_tasked() {
+    let rate_limiter = Arc::new(RateLimiter::new(3, Duration::from_secs(1)));
+    let num_threads = 5;
+    let num_batches = 3;
+
+    let barriers = Arc::new(vec![
+        Barrier::new(num_threads),
+        Barrier::new(num_threads),
+        Barrier::new(num_threads),
+    ]);
+
+    let second_to_result_count = Arc::new(Mutex::new(HashMap::new()));
+
+    let start = Instant::now();
+
+    let mut futures = Vec::new();
+
+    // Queue up all of the tasks immediately, but in the execution order defined by job_ids
+    for _ in 0..num_threads {
+        let rate_limiter = Arc::clone(&rate_limiter);
+        let barriers = Arc::clone(&barriers);
+        let second_to_result_count = Arc::clone(&second_to_result_count);
+
+        let fut = task::spawn(async move {
+            for batch in 0..num_batches {
+                // Just record when this is evaluated
+                let fut = async {
+                    let duration: u64 = (Instant::now() - start).as_secs();
+                    second_to_result_count
+                        .lock()
+                        .await
+                        .entry(duration)
+                        .and_modify(|x| *x += 1)
+                        .or_insert(1);
+                };
+
+                // Wait until all threads are ready to submit their jobs.
+                barriers[batch].wait().await;
+                rate_limiter.rate_limit_future(fut, 1).await;
+            }
+        });
+
+        futures.push(fut);
+    }
+
+    // Just make sure they're all finished.
+    join_all(futures).await;
+
+    let expected = HashMap::from([(0, 3), (1, 3), (2, 3), (3, 3), (4, 3)]);
+
+    assert_eq!(*second_to_result_count.lock().await, expected);
+}
+
+/// Have 5 threads, each submitting 3 jobs. All jobs will have weight 1. We will use barriers such that
+/// the jobs are submitted in batches; one from each thread. We want to check that the number of jobs executed
+/// each second is as expected.
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multi_threaded() {
     let rate_limiter = Arc::new(RateLimiter::new(3, Duration::from_secs(1)));
     let num_threads = 5;

--- a/tests/rate_limiter.rs
+++ b/tests/rate_limiter.rs
@@ -89,7 +89,7 @@ struct JobId {
 #[tokio::test(start_paused = true)]
 async fn test_multi_threaded() {
     let rate_limiter = Arc::new(RateLimiter::new(5, Duration::from_secs(2)));
-    let mut futures = vec![];
+    // let mut futures = vec![];
 
     let job_ids = vec![
         JobId {
@@ -155,6 +155,8 @@ async fn test_multi_threaded() {
     );
 
     let results = Arc::new(Mutex::new(vec![]));
+    // let all_futures = Arc::new(Mutex::new(vec![]));
+    let mut all_futures = vec![];
 
     // Queue up all of the tasks immediately, but in the execution order defined by job_ids
     for thread_id in 0..5 {
@@ -163,7 +165,7 @@ async fn test_multi_threaded() {
         let results = results.clone();
 
         let fut = async move {
-            let mut thread_futures = vec![];
+            let results = results.clone();
             let current_thread_job_ids_and_notifies: Vec<(usize, (JobId, &Notify))> =
                 ordered_job_ids_and_notifies
                     .iter()
@@ -173,7 +175,8 @@ async fn test_multi_threaded() {
 
             for (index, (job_id, notify)) in current_thread_job_ids_and_notifies {
                 let fut = async {
-                    results.lock().await.push(job_id);
+                    let results = results.clone();
+                    &results.lock().await.push(job_id);
                 };
                 // Wait for the previous task to have rate limited its future
                 if index > 0 {
@@ -181,17 +184,17 @@ async fn test_multi_threaded() {
                     prev_notify.notified().await;
                 }
                 let rate_limited_fut = rate_limiter.rate_limit_future(fut, 1);
+                all_futures.push(rate_limited_fut);
                 notify.notify_one();
-                thread_futures.push(rate_limited_fut);
             }
-
-            join_all(thread_futures).await;
         };
 
-        futures.push(fut);
+        fut.await;
+
+        // futures.push(fut);
     }
 
-    join_all(futures).await;
+    join_all(all_futures).await;
 
     assert_eq!(&*results.lock().await, &job_ids);
 }


### PR DESCRIPTION
Make the `RateLimiter` thread-safe.

In testing, it came to my attention that the behaviour was incorrect (overly conservative) in a multi-threaded context, so add plenty of tests to fix that.